### PR TITLE
Update npm react-native alias value

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,8 +582,9 @@ yarn rn
 ```json
 // package.json
 
-"rn": "node node_modules/react-native/local-cli/cli.js",
+"rn": "react-native",
 ```
+**NOTE:** Only works with yarn.
 
 ### Run On Aliases
 


### PR DESCRIPTION
With React Native 0.59, react-native cli extracted from react-native core. They suggesting to use global cli only for bootstrapping and local for everything else.

Reference: https://github.com/react-native-community/cli#using-global-cli